### PR TITLE
Add age confirmation checkbox to signup form and update validation logic

### DIFF
--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -87,6 +87,24 @@ const SignupForm = () => {
               <p className="text-red-500 mt-2">{formState.form_errors[0]}</p>
             )}
           </div>
+          <div className="mb-6">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                name="confirmAge"
+                className="mt-1 rounded border-gray-300"
+              />
+              <span className="text-sm text-gray-700">
+                Potvrđujem da imam 18 godina ili da su mi roditelji dali
+                saglasnost za korišćenje servisa
+              </span>
+            </label>
+            {formState.field_errors && formState.field_errors.confirmAge && (
+              <p className="text-red-500 mt-2">
+                {formState.field_errors.confirmAge[0]}
+              </p>
+            )}
+          </div>
           <button
             type="submit"
             className="w-full bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 rounded-md focus:outline-none">

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -11,6 +11,7 @@ export async function signup(prevState: unknown, formData: FormData) {
     email: formData.get("email"),
     password: formData.get("password"),
     confirmPassword: formData.get("confirmPassword"),
+    confirmAge: formData.get("confirmAge"),
   });
   if (!validated.success) {
     return {
@@ -22,7 +23,7 @@ export async function signup(prevState: unknown, formData: FormData) {
   }
 
   try {
-    const { confirmPassword, ...signupData } = validated.data;
+    const { confirmPassword, confirmAge, ...signupData } = validated.data;
     await apiClient.post("/api/signup/", signupData);
   } catch (error: unknown) {
     // Check if it's a redirect (Next.js throws special error for redirects)

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -11,6 +11,12 @@ export const signupSchema = z
     confirmPassword: z
       .string()
       .min(8, { message: "Password must have 8 characters" }),
+    confirmAge: z.preprocess(
+      (val) => val === "on" || val === true,
+      z.literal(true, {
+        errorMap: () => ({ message: "Obavezna potvrda" }),
+      })
+    ),
   })
   .superRefine(({ password, confirmPassword }, ctx) => {
     if (password != confirmPassword) {


### PR DESCRIPTION
- Introduced a checkbox for users to confirm they are 18 years old or have parental consent in the SignupForm component.
- Updated the signup action to include the confirmAge field in the form data.
- Enhanced the signup schema to validate the confirmAge field, ensuring it is required for form submission.