### PR TITLE
Fix chat: message display, conversations, WebSocket

### DIFF
--- a/src/app/profile/messages/page.tsx
+++ b/src/app/profile/messages/page.tsx
@@ -1,37 +1,107 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import useUserStore from "@/hooks/useUserStore";
-import websocketService from "@/services/websocketService";
+import websocketService, { Message, WebSocketMessage } from "@/services/websocketService";
 import ChatSidebar from "@/components/Chat/ChatSidebar";
 import ChatWindow from "@/components/Chat/ChatWindow";
+import apiClient from "@/services/api";
 
-interface Conversation {
+export interface Conversation {
   username: string;
   lastMessage: string;
   unread: number;
 }
 
-export default function Messages() {
+function buildConversations(
+  messages: Message[],
+  currentUsername: string,
+  ensureUser?: string | null,
+): Conversation[] {
+  const convMap = new Map<string, { lastMessage: string; lastTime: string; unread: number }>();
+
+  for (const msg of messages) {
+    const otherUser = msg.sender === currentUsername ? msg.recipient : msg.sender;
+    const existing = convMap.get(otherUser);
+    const isNewer = !existing || msg.sent_at > existing.lastTime;
+
+    convMap.set(otherUser, {
+      lastMessage: isNewer ? msg.text : existing!.lastMessage,
+      lastTime: isNewer ? msg.sent_at : existing!.lastTime,
+      unread: (existing?.unread ?? 0) + (msg.recipient === currentUsername && !msg.seen ? 1 : 0),
+    });
+  }
+
+  // Ensure the target user appears even without prior messages
+  if (ensureUser && !convMap.has(ensureUser)) {
+    convMap.set(ensureUser, { lastMessage: "", lastTime: "", unread: 0 });
+  }
+
+  return Array.from(convMap.entries())
+    .map(([username, data]) => ({
+      username,
+      lastMessage: data.lastMessage,
+      unread: data.unread,
+    }))
+    .sort((a, b) => {
+      const aTime = convMap.get(a.username)!.lastTime;
+      const bTime = convMap.get(b.username)!.lastTime;
+      return bTime.localeCompare(aTime);
+    });
+}
+
+function MessagesContent() {
   const { user } = useUserStore((state) => state);
+  const searchParams = useSearchParams();
+  const userParam = searchParams.get("user");
+
   const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [activeChat, setActiveChat] = useState<string | null>(null);
-  
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    
-    const token = localStorage.getItem('access_token');
-    if (token && user) {
-      websocketService.connect(token);
-      
-      return () => websocketService.disconnect();
+  const [activeChat, setActiveChat] = useState<string | null>(userParam);
+
+  const loadConversations = useCallback(async () => {
+    if (!user) return;
+    try {
+      const response = await apiClient.get("/api/chat/");
+      const messages: Message[] = response.data;
+      setConversations(buildConversations(messages, user.username, userParam));
+    } catch {
+      if (userParam) {
+        setConversations((prev) =>
+          prev.length === 0 ? [{ username: userParam, lastMessage: "", unread: 0 }] : prev
+        );
+      }
     }
-  }, [user]);
-  
+  }, [user, userParam]);
+
+  // Connect WebSocket and load conversations
+  useEffect(() => {
+    if (typeof window === "undefined" || !user) return;
+
+    const token = localStorage.getItem("access_token");
+    if (token) {
+      websocketService.connect(token);
+    }
+
+    loadConversations();
+
+    const handleWsMessage = (data: WebSocketMessage) => {
+      if (data.type === "message" || data.type === "notification") {
+        loadConversations();
+      }
+    };
+    const unsubscribe = websocketService.subscribe(handleWsMessage);
+
+    return () => {
+      unsubscribe();
+      websocketService.disconnect();
+    };
+  }, [user, loadConversations]);
+
   return (
     <section className="w-full h-[600px] bg-white rounded-xl shadow-md border flex">
-      <ChatSidebar 
-        conversations={conversations} 
+      <ChatSidebar
+        conversations={conversations}
         activeChat={activeChat}
         onSelectChat={setActiveChat}
       />
@@ -43,5 +113,19 @@ export default function Messages() {
         </div>
       )}
     </section>
+  );
+}
+
+export default function Messages() {
+  return (
+    <Suspense
+      fallback={
+        <section className="w-full h-[600px] bg-white rounded-xl shadow-md border flex items-center justify-center text-gray-500">
+          Loading messages...
+        </section>
+      }
+    >
+      <MessagesContent />
+    </Suspense>
   );
 }

--- a/src/components/Chat/ChatWindow.tsx
+++ b/src/components/Chat/ChatWindow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
-import { Message } from "@/services/websocketService";
+import { useEffect, useState, useRef, useCallback } from "react";
+import { Message, WebSocketMessage } from "@/services/websocketService";
 import websocketService from "@/services/websocketService";
 import MessageBubble from "./MessageBubble";
 import apiClient from "@/services/api";
@@ -18,50 +18,52 @@ export default function ChatWindow({ username }: ChatWindowProps) {
   const [isLoading, setIsLoading] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    // Load message history
-    const loadMessages = async () => {
-      try {
-        const response = await apiClient.get(`/api/chat/conversation/${username}/`);
-        setMessages(response.data);
-        // Mark messages as seen
-        if (user) {
-          const unseenMessageIds = response.data
-            .filter((msg: Message) => msg.recipient === user.username && !msg.seen)
-            .map((msg: Message) => msg.id);
-          if (unseenMessageIds.length > 0) {
-            await apiClient.post('/api/chat/mark/', { ids_to_mark: unseenMessageIds }).catch(() => {
-              // Silently fail if marking as seen fails
-            });
-          }
+  const loadMessages = useCallback(async () => {
+    try {
+      const response = await apiClient.get(`/api/chat/conversation/${username}/`);
+      setMessages(response.data);
+      if (user) {
+        const unseenIds = response.data
+          .filter((msg: Message) => msg.recipient === user.username && !msg.seen)
+          .map((msg: Message) => msg.id);
+        if (unseenIds.length > 0) {
+          apiClient.post("/api/chat/mark/", { ids_to_mark: unseenIds }).catch(() => {});
         }
-        setIsLoading(false);
-      } catch (error) {
-        setIsLoading(false);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setIsLoading(false);
+    }
+  }, [username, user]);
+
+  useEffect(() => {
+    setMessages([]);
+    setIsLoading(true);
+    loadMessages();
+
+    const handleWsMessage = (data: WebSocketMessage) => {
+      if (data.type === "message") {
+        const isRelevant = data.sender === username || data.recipient === username;
+        if (isRelevant) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: Date.now(),
+              sender: data.sender || "",
+              recipient: data.recipient || "",
+              text: data.message || "",
+              seen: false,
+              sent_at: new Date().toISOString(),
+            },
+          ]);
+        }
       }
     };
 
-    loadMessages();
-
-    // Subscribe to new messages
-    const unsubscribe = websocketService.subscribe((data) => {
-      if (data.type === 'message' && (data.sender === username || data.recipient === username)) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: Date.now(),
-            sender: data.sender || '',
-            recipient: data.recipient || '',
-            text: data.message || '',
-            seen: false,
-            sent_at: new Date().toISOString(),
-          },
-        ]);
-      }
-    });
-
+    const unsubscribe = websocketService.subscribe(handleWsMessage);
     return unsubscribe;
-  }, [username]);
+  }, [username, loadMessages]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -85,9 +87,15 @@ export default function ChatWindow({ username }: ChatWindowProps) {
 
   return (
     <div className="flex-1 flex flex-col">
+      <div className="p-4 border-b">
+        <h3 className="font-bold">{username}</h3>
+      </div>
       <div className="flex-1 overflow-y-auto p-4">
-        {messages.map((message) => (
-          <MessageBubble key={message.id} message={message} />
+        {messages.length === 0 && (
+          <div className="text-center text-gray-400 mt-8">No messages yet. Say hello!</div>
+        )}
+        {messages.map((message, index) => (
+          <MessageBubble key={`${message.id}-${index}`} message={message} />
         ))}
         <div ref={messagesEndRef} />
       </div>
@@ -111,4 +119,3 @@ export default function ChatWindow({ username }: ChatWindowProps) {
     </div>
   );
 }
-

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -20,44 +20,49 @@ export interface Message {
 class WebSocketService {
   private ws: WebSocket | null = null;
   private handlers: MessageHandler[] = [];
-  
+  private intentionalClose = false;
+
   connect(token: string) {
     if (typeof window === 'undefined') return;
-    
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      return;
+    }
+
+    this.intentionalClose = false;
     const wsUrl = `${process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000'}/ws/chat/?token=${token}`;
     this.ws = new WebSocket(wsUrl);
-    
+
     this.ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
       this.handlers.forEach(handler => handler(data));
     };
-    
+
     this.ws.onclose = () => {
-      // Reconnect logic
-      if (typeof window !== 'undefined') {
+      if (!this.intentionalClose && typeof window !== 'undefined') {
         setTimeout(() => this.connect(token), 3000);
       }
     };
-    
+
     this.ws.onerror = (error) => {
       console.error('WebSocket error:', error);
     };
   }
-  
+
   sendMessage(recipient: string, message: string) {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify({ recipient, message }));
     }
   }
-  
+
   subscribe(handler: MessageHandler) {
     this.handlers.push(handler);
     return () => {
       this.handlers = this.handlers.filter(h => h !== handler);
     };
   }
-  
+
   disconnect() {
+    this.intentionalClose = true;
     if (this.ws) {
       this.ws.close();
       this.ws = null;
@@ -66,4 +71,3 @@ class WebSocketService {
 }
 
 export default new WebSocketService();
-


### PR DESCRIPTION
## Summary
- **Read `?user=` query param**: clicking "Message Seller" now opens the chat window immediately
- **Load conversation list**: sidebar populated from `/api/chat/` API, updates on new messages
- **Fix WebSocket**: prevent duplicate connections, stop reconnect loop on intentional disconnect
- **ChatWindow improvements**: reset state on conversation switch, show username header, empty state placeholder

## Test plan
- [x] `pnpm build` passes
- [ ] Open chat via "Message Seller" button — chat window appears with input field
- [ ] Send message — appears as blue bubble on sender side
- [ ] Receive message — appears as gray bubble on recipient side
- [ ] Sidebar shows conversation list with last message


🤖 Generated with [Claude Code](https://claude.com/claude-code)