### PR TITLE
Fix deploy: clean stale .next cache before rsync

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,12 +18,15 @@ ssh ${SSH_USER}@${SSH_HOST} << ENDSSH
   mkdir -p \${FRONTEND_PATH}/logs
 ENDSSH
 
+# Remove old .next build to avoid stale cache conflicts
+echo "Cleaning old build artifacts..."
+ssh ${SSH_USER}@${SSH_HOST} "rm -rf ${FRONTEND_PATH}/.next"
+
 # Copy built application
 echo "Copying application files..."
 rsync -avz --delete \
   --exclude='.git' \
   --exclude='node_modules' \
-  --exclude='.next/cache' \
   --exclude='.env' \
   --exclude='logs' \
   --exclude='*.log' \


### PR DESCRIPTION
## Summary
- Remove old `.next` directory on server before rsync to prevent stale cache conflicts
- Previous deploys returned 500 due to `getStagedRenderingController is not a function` from old Next.js build artifacts

## Test plan
- [ ] Push to main → deploy should pass health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)