### PR TITLE
Fix deploy: build on server to fix SSR errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,12 +30,6 @@ jobs:
       # Note: Unit tests can be added here with: pnpm test
       # E2E tests are excluded from CI/CD as they require backend server
 
-      - name: Build application
-        run: pnpm build
-        env:
-          NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL || 'https://api.sb.maria.rezvov.com' }}
-          NEXT_PUBLIC_WS_URL: ${{ vars.NEXT_PUBLIC_WS_URL || 'wss://api.sb.maria.rezvov.com' }}
-
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -58,4 +52,6 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/opt/sbook' }}
           FRONTEND_PORT: ${{ vars.FRONTEND_PORT || '3000' }}
+          NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL || 'https://api.sb.maria.rezvov.com' }}
+          NEXT_PUBLIC_WS_URL: ${{ vars.NEXT_PUBLIC_WS_URL || 'wss://api.sb.maria.rezvov.com' }}
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -14,19 +14,16 @@ ssh ${SSH_USER}@${SSH_HOST} << ENDSSH
   set -e
   DEPLOY_PATH="${DEPLOY_PATH:-/opt/sbook}"
   FRONTEND_PATH="\${DEPLOY_PATH}/frontend"
-  
+
   mkdir -p \${FRONTEND_PATH}/logs
 ENDSSH
 
-# Remove old .next build to avoid stale cache conflicts
-echo "Cleaning old build artifacts..."
-ssh ${SSH_USER}@${SSH_HOST} "rm -rf ${FRONTEND_PATH}/.next"
-
-# Copy built application
+# Copy source files (exclude .next — will build on server)
 echo "Copying application files..."
 rsync -avz --delete \
   --exclude='.git' \
   --exclude='node_modules' \
+  --exclude='.next' \
   --exclude='.env' \
   --exclude='logs' \
   --exclude='*.log' \
@@ -37,37 +34,37 @@ ssh ${SSH_USER}@${SSH_HOST} bash << ENDSSH
   set -e
   DEPLOY_PATH="${DEPLOY_PATH:-/opt/sbook}"
   FRONTEND_PATH="\${DEPLOY_PATH}/frontend"
-  
+
   echo "Checking system dependencies..."
-  
+
   # Check required commands and tools
   MISSING_DEPS=""
-  
+
   # Check node (should come with npm)
   if ! command -v node &> /dev/null; then
     MISSING_DEPS="\${MISSING_DEPS}node "
   fi
-  
+
   # Check curl (needed for health checks)
   if ! command -v curl &> /dev/null; then
     MISSING_DEPS="\${MISSING_DEPS}curl "
   fi
-  
+
   # Activate pnpm and check availability
   export PNPM_HOME="\$HOME/.local/share/pnpm"
   if [ -d "\$PNPM_HOME" ]; then
     export PATH="\$PNPM_HOME:\$PATH"
   fi
-  
+
   if ! command -v pnpm &> /dev/null; then
     MISSING_DEPS="\${MISSING_DEPS}pnpm "
   fi
-  
+
   # Check pm2 (should be available after pnpm is activated)
   if ! command -v pm2 &> /dev/null; then
     MISSING_DEPS="\${MISSING_DEPS}pm2 "
   fi
-  
+
   # Fail fast if dependencies are missing
   if [ -n "\${MISSING_DEPS}" ]; then
     echo "ERROR: Missing required system dependencies: \${MISSING_DEPS}"
@@ -87,23 +84,24 @@ ssh ${SSH_USER}@${SSH_HOST} bash << ENDSSH
     fi
     exit 1
   fi
-  
+
   echo "All system dependencies are available"
-  
+
   cd \${FRONTEND_PATH}
-  
+
   echo "Installing dependencies..."
-  # Use --no-frozen-lockfile to allow pnpm to update lockfile if versions differ
-  # This handles cases where pnpm version on server differs from lockfile version
-  # Lockfile is not copied to server (in .gitignore), so we generate it from package.json
   pnpm install --no-frozen-lockfile
-  
+
+  echo "Building application on server..."
+  NEXT_PUBLIC_API_BASE_URL="${NEXT_PUBLIC_API_BASE_URL:-https://api.sb.maria.rezvov.com}" \
+  NEXT_PUBLIC_WS_URL="${NEXT_PUBLIC_WS_URL:-wss://api.sb.maria.rezvov.com}" \
+  pnpm build
+
   echo "Updating PM2 configuration..."
-  # Export environment variables for PM2 ecosystem config
   export FRONTEND_PORT="\${FRONTEND_PORT:-3000}"
   export DEPLOY_PATH="\${DEPLOY_PATH}"
   export PNPM_PATH="\${PNPM_HOME}/pnpm"
-  
+
   if [ -f deploy/sbook-frontend.ecosystem.config.js ]; then
     pm2 delete sbook-frontend || true
     pm2 start deploy/sbook-frontend.ecosystem.config.js
@@ -113,16 +111,15 @@ ssh ${SSH_USER}@${SSH_HOST} bash << ENDSSH
     pm2 restart sbook-frontend || pm2 start pnpm --name sbook-frontend -- start
     pm2 save
   fi
-  
+
   echo "Waiting for service to start..."
   sleep 3
-  
+
   echo "Health check..."
   FRONTEND_PORT="${FRONTEND_PORT:-3000}"
   curl -f http://127.0.0.1:\${FRONTEND_PORT} || exit 1
-  
+
   echo "Deployment completed successfully"
 ENDSSH
 
 echo "Frontend deployment finished"
-


### PR DESCRIPTION
## Summary
- Build Next.js on server instead of copying CI-built `.next` — fixes SSR 500 errors caused by environment differences between CI runner and production server
- Remove CI build step (no longer needed since build happens on server)
- Pass `NEXT_PUBLIC_*` env vars to deploy script for server-side build

## Test plan
- [ ] Push to main → deploy should build on server and pass health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)